### PR TITLE
 Issue #88 Fix: recent conversation do not need to be reloaded

### DIFF
--- a/apps/saru/components/chat/chat.tsx
+++ b/apps/saru/components/chat/chat.tsx
@@ -16,6 +16,7 @@ import { DataStreamHandler } from '@/components/data-stream-handler';
 import { motion } from 'framer-motion';
 import { Loader2 } from 'lucide-react';
 import { useAiOptionsValue } from '@/hooks/ai-options';
+import { mutate as globalMutate } from 'swr';
 
 export interface ChatProps {
   id?: string;
@@ -179,6 +180,7 @@ export function Chat({
       if (detail.chatId !== chatId) {
           setChatId(detail.chatId);
           setRequestedChatLoadId(detail.chatId);
+          globalMutate('/api/history');
       }
     };
 

--- a/apps/saru/hooks/use-document.ts
+++ b/apps/saru/hooks/use-document.ts
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { generateUUID } from "@/lib/utils";
 import { useSidebar } from "@/components/ui/sidebar";
-
+import { mutate as globalMutate } from 'swr';
 export interface CurrentDocument {
   documentId: string;
   title: string;
@@ -60,6 +60,8 @@ export function useDocument() {
   const handleResetChat = useCallback(() => {
     console.log('[useDocument] Resetting chat state');
     window.dispatchEvent(new CustomEvent('reset-chat-state'));
+
+    globalMutate('/api/history');
     
     if (openMobile) {
       setOpenMobile(false);

--- a/apps/saru/hooks/use-document.ts
+++ b/apps/saru/hooks/use-document.ts
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { generateUUID } from "@/lib/utils";
 import { useSidebar } from "@/components/ui/sidebar";
 import { mutate as globalMutate } from 'swr';
+
 export interface CurrentDocument {
   documentId: string;
   title: string;
@@ -60,7 +61,6 @@ export function useDocument() {
   const handleResetChat = useCallback(() => {
     console.log('[useDocument] Resetting chat state');
     window.dispatchEvent(new CustomEvent('reset-chat-state'));
-
     globalMutate('/api/history');
     
     if (openMobile) {


### PR DESCRIPTION
If someone clicks on new chat, then the recent chat did not appear in the recent conversation immediately, it needs a reload, but now, i have just added a line that will help the recent conversation to refresh automatically whenever the chat is reset or handleResetChat function is triggered, This will help the user to see its recent conversation without reloading. I am attaching a video that will show how it is working and the build is successful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * History now refreshes immediately when resetting or switching chats, preventing stale conversations from appearing.

* **UX Improvements**
  * Consistent, up-to-date chat history across views and sessions so users see the latest conversation state without manual refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->