### PR TITLE
fix: uneditable editor input

### DIFF
--- a/apps/saru/components/document/document-workspace.tsx
+++ b/apps/saru/components/document/document-workspace.tsx
@@ -276,18 +276,6 @@ export function AlwaysVisibleArtifact({
       
       if (originalDocumentId !== document.documentId) return;
       
-      if (
-        typeof versionIndex !== 'number' ||
-        versionIndex < 0 ||
-        versionIndex >= documents.length - 1 
-      ) {
-        toast.error('Cannot fork from current version or invalid version');
-        return;
-      }
-      if (!forkFromTimestamp) {
-        toast.error('Missing fork timestamp');
-        return;
-      }
 
       console.log('[DocumentWorkspace] Handling version fork from index', versionIndex, 'timestamp', forkFromTimestamp);
       

--- a/apps/saru/components/document/version-rail.tsx
+++ b/apps/saru/components/document/version-rail.tsx
@@ -121,11 +121,11 @@ export function VersionRail({ versions, currentIndex, onIndexChange, baseDocumen
 
   const triggerFork = (idx: number) => {
     const version = versions[idx];
-    if (!version || idx >= versions.length - 1) return;
-    
+    if (!version) return;
+
     window.dispatchEvent(
       new CustomEvent('version-fork', {
-        detail: { 
+        detail: {
           originalDocumentId: baseDocumentId,
           versionIndex: idx,
           forkFromTimestamp: version.createdAt,
@@ -209,9 +209,6 @@ export function VersionRail({ versions, currentIndex, onIndexChange, baseDocumen
       setHoverIndex(null);
     }
 
-    if (isViewingHistory) {
-      commitIndex(versions.length - 1);
-    }
   };
 
   const Tooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: { ts: string; additions: number; deletions: number } }> }) => {

--- a/apps/saru/lib/editor/diff-plugin.ts
+++ b/apps/saru/lib/editor/diff-plugin.ts
@@ -23,7 +23,8 @@ export function diffPlugin(documentId: string): Plugin {
 
         if (!previewActiveRef) {
           previewOriginalContentRef = buildContentFromDocument(editorView.state.doc);
-          editorView.dom.setAttribute('contenteditable', 'false');
+          // Commented out: editorView.dom.setAttribute('contenteditable', 'false');
+          // Let the Editor component handle editability
         }
 
         const oldContent = previewOriginalContentRef ?? buildContentFromDocument(editorView.state.doc);
@@ -64,7 +65,8 @@ export function diffPlugin(documentId: string): Plugin {
         previewActiveRef = false;
         previewOriginalContentRef = null;
         lastPreviewContentRef = null;
-        editorView.dom.setAttribute('contenteditable', 'true');
+        // Commented out: editorView.dom.setAttribute('contenteditable', 'true');
+        // Let the Editor component handle editability
       };
 
       const handleApply = (event: CustomEvent) => {
@@ -109,7 +111,8 @@ export function diffPlugin(documentId: string): Plugin {
 
         editorView.dom.classList.add('applying-changes');
         setTimeout(finalizeApply, animationDuration);
-        editorView.dom.setAttribute('contenteditable', 'true');
+        // Commented out: editorView.dom.setAttribute('contenteditable', 'true');
+        // Let the Editor component handle editability
       };
 
       window.addEventListener('preview-document-update', handlePreviewUpdate as EventListener);


### PR DESCRIPTION
This PR fixes the uneditable editor input reported here: https://x.com/studio_hungry/status/1962794756439716321


### Fix Screen recording


https://github.com/user-attachments/assets/bcb4eef3-6963-40aa-98c2-3a074cbeac46



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Prevents the editor from unexpectedly switching between editable and read-only during preview, cancel, or apply, improving focus and interaction stability.
- Refactor
  - Editability handling delegated to the main editor for consistent behavior.
  - Version fork flow now relies on server validation and allows forking from the latest version; leaving a version preview no longer auto-commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->