### PR TITLE
feat: restore session check on landing page

### DIFF
--- a/apps/saru/app/page.tsx
+++ b/apps/saru/app/page.tsx
@@ -20,7 +20,9 @@ const crimson = Crimson_Text({
 
 export default function Home() {
   const router = useRouter();
-  const [hasSession, setHasSession] = useState<boolean>(false);
+
+  const { data: session } = authClient.useSession();
+  const hasSession = !!session?.user;
 
   const [starGoal, setStarGoal] = useState(0);
   const { count: animatedStarCount } = useCounter(starGoal);
@@ -35,26 +37,6 @@ export default function Home() {
       })
       .catch(() => {});
   }, []);
-
-  useEffect(() => {
-    const checkSession = async () => {
-      try {
-        const { data: session, error } = await authClient.getSession();
-        if (error) {
-          console.error("Error fetching session:", error);
-          return;
-        }
-
-        const isLoggedIn = !!session?.user;
-        setHasSession(isLoggedIn);
-
-      } catch (error) {
-        console.error("Error checking session unexpectedly:", error);
-      }
-    };
-
-    checkSession();
-  }, [router]);
 
   const handleBeginClick = () => {
     if (hasSession) {


### PR DESCRIPTION
## Summary
- derive landing page session state with `authClient.useSession`
- ensure "Open" CTA displays when a session exists

## Testing
- `pnpm --filter @saru/app lint`
- `pnpm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82c06d39c8325abb207de90f87da4